### PR TITLE
Add socket ID in header vs. monkey patching Backbone.sync

### DIFF
--- a/src/backpusher.js
+++ b/src/backpusher.js
@@ -100,12 +100,16 @@
     'read'  : 'GET'
   };
 
-  // Add socket ID to every jquery AJAX request
-  $.ajaxPrefilter(function(options, originalOptions, xhr) {
-    if (!options.crossDomain) {
-      xhr.setRequestHeader("X-Pusher-Socket-ID", Backbone.pusher_socket_id);
-    }
-  });
+  // Add socket ID to every Backbone.sync request
+  var origBackboneSync = Backbone.sync;
+  Backbone.sync = function(method, model, options) {
+    options.headers = _.extend(
+      { 'X-Pusher-Socket-ID': Backbone.pusher_socket_id },
+      options.headers
+    );
+
+    origBackboneSync(method, model, options);
+  };
 
   // Export:
   exports.Backpusher = Backpusher;

--- a/src/backpusher.js
+++ b/src/backpusher.js
@@ -100,56 +100,10 @@
     'read'  : 'GET'
   };
 
-  Backbone.sync = function(method, model, options) {
-    var type = methodMap[method];
-
-    // Default JSON-request options.
-    var params = _.extend({
-      type:         type,
-      dataType:     'json'
-    }, options);
-
-    if (!(model && model.url)) {
-      throw new Error("A 'url' property or function must be specified");
-    }
-
-    if (!params.url) {
-      params.url = _.isFunction(model.url) ? model.url() : model.url;
-      params.url += '?socket_id=' + Backbone.pusher_socket_id;
-    }
-
-    // Ensure that we have the appropriate request data.
-    if (!params.data && model && (method == 'create' || method == 'update')) {
-      params.contentType = 'application/json';
-      params.data = JSON.stringify(model.toJSON());
-    }
-
-    // For older servers, emulate JSON by encoding the request into an HTML-form.
-    if (Backbone.emulateJSON) {
-      params.contentType = 'application/x-www-form-urlencoded';
-      params.data        = params.data ? {model : params.data} : {};
-    }
-
-    // For older servers, emulate HTTP by mimicking the HTTP method with `_method`
-    // And an `X-HTTP-Method-Override` header.
-    if (Backbone.emulateHTTP) {
-      if (type === 'PUT' || type === 'DELETE') {
-        if (Backbone.emulateJSON) params.data._method = type;
-        params.type = 'POST';
-        params.beforeSend = function(xhr) {
-          xhr.setRequestHeader('X-HTTP-Method-Override', type);
-        };
-      }
-    }
-
-    // Don't process data on a non-GET request.
-    if (params.type !== 'GET' && !Backbone.emulateJSON) {
-      params.processData = false;
-    }
-
-    // Make the request.
-    return $.ajax(params);
-  };
+  // Add socket ID to every jquery AJAX request
+  $.ajaxPrefilter(function(options, originalOptions, xhr) {
+    xhr.setRequestHeader("X-Pusher-Socket-ID", Backbone.pusher_socket_id);
+  });
 
   // Export:
   exports.Backpusher = Backpusher;

--- a/src/backpusher.js
+++ b/src/backpusher.js
@@ -102,7 +102,9 @@
 
   // Add socket ID to every jquery AJAX request
   $.ajaxPrefilter(function(options, originalOptions, xhr) {
-    xhr.setRequestHeader("X-Pusher-Socket-ID", Backbone.pusher_socket_id);
+    if (!options.crossDomain) {
+      xhr.setRequestHeader("X-Pusher-Socket-ID", Backbone.pusher_socket_id);
+    }
   });
 
   // Export:


### PR DESCRIPTION
Having `Backbone.sync` duplicated just to add the `socket_id` to the params seems undesirable.

Modifying the URL also seems potentially risky vs. adding the socket_id in a header which is less obtrusive.
